### PR TITLE
feat: added the possibility to assign global before/after for runTest/fixture/test (part1/fixture)

### DIFF
--- a/src/api/structure/fixture.ts
+++ b/src/api/structure/fixture.ts
@@ -20,15 +20,19 @@ export default class Fixture extends TestingUnit {
     public afterEachFn: Function | null;
     public beforeFn: Function | null;
     public afterFn: Function | null;
+    public globalBeforeFn: Function | null;
+    public globalAfterFn: Function | null;
 
     public constructor (testFile: TestFile) {
         super(testFile, UnitType.fixture, SPECIAL_BLANK_PAGE);
 
-        this.path         = testFile.filename;
-        this.beforeEachFn = null;
-        this.afterEachFn  = null;
-        this.beforeFn     = null;
-        this.afterFn      = null;
+        this.path           = testFile.filename;
+        this.beforeEachFn   = null;
+        this.afterEachFn    = null;
+        this.beforeFn       = null;
+        this.afterFn        = null;
+        this.globalBeforeFn = null;
+        this.globalAfterFn  = null;
 
         return this.apiOrigin as unknown as Fixture;
     }

--- a/src/configuration/interfaces.ts
+++ b/src/configuration/interfaces.ts
@@ -12,6 +12,17 @@ export interface Dictionary<T> {
     [key: string]: T;
 }
 
+interface Hook {
+    before?: Function;
+    after?: Function;
+}
+
+export interface Hooks {
+    runTest?: Hook;
+    fixture?: Hook;
+    test?: Hook;
+}
+
 export interface RunnerRunOptions {
     skipJsErrors?: boolean;
     skipUncaughtErrors?: boolean;
@@ -30,6 +41,7 @@ export interface RunnerRunOptions {
     pageRequestTimeout?: number;
     ajaxRequestTimeout?: number;
     retryTestPages?: boolean;
+    hooks?: Hooks;
 }
 
 export interface GetOptionConfiguration {

--- a/src/configuration/interfaces.ts
+++ b/src/configuration/interfaces.ts
@@ -12,17 +12,6 @@ export interface Dictionary<T> {
     [key: string]: T;
 }
 
-interface Hook {
-    before?: Function;
-    after?: Function;
-}
-
-export interface Hooks {
-    runTest?: Hook;
-    fixture?: Hook;
-    test?: Hook;
-}
-
 export interface RunnerRunOptions {
     skipJsErrors?: boolean;
     skipUncaughtErrors?: boolean;
@@ -41,7 +30,7 @@ export interface RunnerRunOptions {
     pageRequestTimeout?: number;
     ajaxRequestTimeout?: number;
     retryTestPages?: boolean;
-    hooks?: Hooks;
+    hooks?: HooksValue;
 }
 
 export interface GetOptionConfiguration {

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -45,7 +45,8 @@ enum OptionNames {
     compilerOptions = 'compilerOptions',
     pageRequestTimeout = 'pageRequestTimeout',
     ajaxRequestTimeout = 'ajaxRequestTimeout',
-    cache = 'cache'
+    cache = 'cache',
+    hooks = 'hooks',
 }
 
 export default OptionNames;

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -18,7 +18,7 @@ interface Hook {
 }
 
 interface HooksValue {
-    runTest?: Hook;
+    testRun?: Hook;
     fixture?: Hook;
     test?: Hook;
 }

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -12,4 +12,15 @@ interface QuarantineOptionValue {
     successThreshold?: number;
 }
 
-type OptionValue = undefined | null | string | boolean | number | string[] | Function | { [key: string]: any } | ScreenshotOptionValue | QuarantineOptionValue | CompilerOptions;
+interface Hook {
+    before?: Function;
+    after?: Function;
+}
+
+interface HooksValue {
+    runTest?: Hook;
+    fixture?: Hook;
+    test?: Hook;
+}
+
+type OptionValue = undefined | null | string | boolean | number | string[] | Function | { [key: string]: any } | ScreenshotOptionValue | QuarantineOptionValue | CompilerOptions | HooksValue;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -189,6 +189,18 @@ export default class Bootstrapper {
         return compiler.getTests();
     }
 
+    private _setGlobalHooksToTest (tests: Test[]): Test[] {
+        const fixtureBefore = this.hooks?.fixture?.before || null;
+        const fixtureAfter = this.hooks?.fixture?.after || null;
+
+        return tests.map(item => {
+            item.fixture.globalBeforeFn = fixtureBefore;
+            item.fixture.globalAfterFn = fixtureAfter;
+
+            return item;
+        });
+    }
+
     private async _getTests (): Promise<Test[]> {
         const cwd        = process.cwd();
         const sourceList = await parseFileList(this.sources, cwd);
@@ -221,6 +233,8 @@ export default class Bootstrapper {
 
         if (!tests.length)
             throw new GeneralError(RUNTIME_ERRORS.noTestsToRunDueFiltering);
+
+        tests = this._setGlobalHooksToTest(tests);
 
         return tests;
     }

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -33,6 +33,7 @@ import { BootstrapperInit, BrowserSetOptions } from './interfaces';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import guardTimeExecution from '../utils/guard-time-execution';
+import { Hooks } from '../configuration/interfaces';
 
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
@@ -94,6 +95,7 @@ export default class Bootstrapper {
     public disableMultipleWindows: boolean;
     public compilerOptions?: CompilerOptions;
     public browserInitTimeout?: number;
+    public hooks?: Hooks;
 
     private readonly compilerService?: CompilerService;
     private readonly debugLogger: debug.Debugger;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -33,7 +33,6 @@ import { BootstrapperInit, BrowserSetOptions } from './interfaces';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import guardTimeExecution from '../utils/guard-time-execution';
-import { Hooks } from '../configuration/interfaces';
 
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
@@ -95,7 +94,7 @@ export default class Bootstrapper {
     public disableMultipleWindows: boolean;
     public compilerOptions?: CompilerOptions;
     public browserInitTimeout?: number;
-    public hooks?: Hooks;
+    public hooks?: HooksValue;
 
     private readonly compilerService?: CompilerService;
     private readonly debugLogger: debug.Debugger;

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -60,9 +60,9 @@ export default class FixtureHookController {
     }
 
     private async _runFixtureBeforeHook (item: FixtureState, fn: Function): Promise<boolean> {
-        const shouldRunGlobalBeforeHook = !item.started && fn;
+        const shouldRunBeforeHook = !item.started && fn;
 
-        if (!shouldRunGlobalBeforeHook)
+        if (!shouldRunBeforeHook)
             return !item.fixtureBeforeHookErr;
 
         item.runningFixtureBeforeHook = true;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -469,6 +469,7 @@ export default class Runner extends EventEmitter {
         this.bootstrapper.disableMultipleWindows = this.configuration.getOption(OPTION_NAMES.disableMultipleWindows);
         this.bootstrapper.compilerOptions        = this.configuration.getOption(OPTION_NAMES.compilerOptions);
         this.bootstrapper.browserInitTimeout     = this.configuration.getOption(OPTION_NAMES.browserInitTimeout);
+        this.bootstrapper.hooks                  = this.configuration.getOption(OPTION_NAMES.hooks);
     }
 
     async _prepareClientScripts (tests, clientScripts) {

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -132,8 +132,16 @@ describe('[API] fixture.before/fixture.after hooks', () => {
 });
 
 describe('[API] fixture global before/after hooks', () => {
-    global.fixtureBefore = 0;
-    global.fixtureAfter  = 0;
+    before(() => {
+        global.fixtureBefore = 0;
+        global.fixtureAfter  = 0;
+    });
+
+    after(() => {
+        delete global.fixtureBefore;
+        delete global.fixtureAfter;
+    });
+
 
     const hooks = {
         fixture: {
@@ -153,7 +161,4 @@ describe('[API] fixture global before/after hooks', () => {
     it('Should run hooks for all fixture', () => {
         return runTests('./testcafe-fixtures/fixture-hooks-global.js', null, { only: 'chrome', hooks });
     });
-
-    delete global.fixtureBefore;
-    delete global.fixtureAfter;
 });

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -1,3 +1,4 @@
+const delay      = require('../../../../../../lib/utils/delay');
 const { expect } = require('chai');
 const { uniq }   = require('lodash');
 const config     = require('../../../../config');
@@ -128,4 +129,31 @@ describe('[API] fixture.before/fixture.after hooks', () => {
     it('Fixture context', () => {
         return runTests('./testcafe-fixtures/fixture-ctx.js', null, { only: 'chrome, firefox' });
     });
+});
+
+describe('[API] fixture global before/after hooks', () => {
+    global.fixtureBefore = 0;
+    global.fixtureAfter  = 0;
+
+    const hooks = {
+        fixture: {
+            before: async () => {
+                await delay(100);
+
+                global.fixtureBefore++;
+            },
+            after: async () => {
+                await delay(100);
+
+                global.fixtureAfter++;
+            }
+        }
+    };
+
+    it('Should run hooks for all fixture', () => {
+        return runTests('./testcafe-fixtures/fixture-hooks-global.js', null, { only: 'chrome', hooks });
+    });
+
+    delete global.fixtureBefore;
+    delete global.fixtureAfter;
 });

--- a/test/functional/fixtures/api/es-next/hooks/testcafe-fixtures/fixture-hooks-global.js
+++ b/test/functional/fixtures/api/es-next/hooks/testcafe-fixtures/fixture-hooks-global.js
@@ -1,0 +1,21 @@
+fixture `Fixture 1`;
+
+test('Test1', async t => {
+    await t
+        .expect(global.fixtureBefore).eql(1)
+        .expect(global.fixtureAfter).eql(0);
+});
+
+test('Test2', async t => {
+    await t
+        .expect(global.fixtureBefore).eql(1)
+        .expect(global.fixtureAfter).eql(0);
+});
+
+fixture `Fixture2`;
+
+test('Test3', async t => {
+    await t
+        .expect(global.fixtureBefore).eql(2)
+        .expect(global.fixtureAfter).eql(1);
+});

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -226,7 +226,8 @@ before(function () {
                     disableScreenshots,
                     disableMultipleWindows,
                     pageRequestTimeout,
-                    ajaxRequestTimeout
+                    ajaxRequestTimeout,
+                    hooks
                 } = opts;
 
                 const actualBrowsers = browsersInfo.filter(browserInfo => {
@@ -290,7 +291,8 @@ before(function () {
                         disableScreenshots,
                         disableMultipleWindows,
                         pageRequestTimeout,
-                        ajaxRequestTimeout
+                        ajaxRequestTimeout,
+                        hooks,
                     })
                     .then(failedCount => {
                         if (customReporters)


### PR DESCRIPTION
[closes DevExpress/testcafe#745]

## Purpose
Realize the possibility to assign global before/after for runTest/fixture/test to perform any actions in the appropriate conditions.

## Approach
1. Add the tests for feature
2. Add the property 'hooks' processing
3. Add execution before/after fixture hooks

## References
https://github.com/DevExpress/testcafe/issues/745

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
