### PR TITLE
feat: added the possibility to assign global before/after for runTest/fixture/test (part2/test)

### DIFF
--- a/src/api/structure/test.ts
+++ b/src/api/structure/test.ts
@@ -21,6 +21,8 @@ export default class Test extends TestingUnit {
     public fn: Function | null;
     public beforeFn: Function | null;
     public afterFn: Function | null;
+    public globalBeforeFn: Function | null;
+    public globalAfterFn: Function | null;
     public timeouts: TestTimeouts | null;
 
     public constructor (testFile: TestFile) {
@@ -30,11 +32,13 @@ export default class Test extends TestingUnit {
 
         super(testFile, UnitType.test, pageUrl);
 
-        this.fixture  = fixture;
-        this.fn       = null;
-        this.beforeFn = null;
-        this.afterFn  = null;
-        this.timeouts = null;
+        this.fixture        = fixture;
+        this.fn             = null;
+        this.beforeFn       = null;
+        this.afterFn        = null;
+        this.globalBeforeFn = null;
+        this.globalAfterFn  = null;
+        this.timeouts       = null;
 
         if (this.fixture) {
             this.requestHooks  = this.fixture.requestHooks.slice();

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -34,6 +34,7 @@ import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import guardTimeExecution from '../utils/guard-time-execution';
 import { Hooks } from '../configuration/interfaces';
+import wrapTestFunction from '../api/wrap-test-function';
 
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
@@ -189,13 +190,12 @@ export default class Bootstrapper {
         return compiler.getTests();
     }
 
-    private _setGlobalHooksToTest (tests: Test[]): Test[] {
-        const fixtureBefore = this.hooks?.fixture?.before || null;
-        const fixtureAfter = this.hooks?.fixture?.after || null;
-
+    private _setGlobalHooksToTests (tests: Test[]): Test[] {
         return tests.map(item => {
-            item.fixture.globalBeforeFn = fixtureBefore;
-            item.fixture.globalAfterFn = fixtureAfter;
+            item.fixture.globalBeforeFn = this.hooks?.fixture?.before || null;
+            item.fixture.globalAfterFn = this.hooks?.fixture?.after || null;
+            item.globalBeforeFn = this.hooks?.test?.before ? wrapTestFunction(this.hooks.test.before) : null;
+            item.globalAfterFn = this.hooks?.test?.after ? wrapTestFunction(this.hooks.test.after) : null;
 
             return item;
         });
@@ -234,7 +234,7 @@ export default class Bootstrapper {
         if (!tests.length)
             throw new GeneralError(RUNTIME_ERRORS.noTestsToRunDueFiltering);
 
-        tests = this._setGlobalHooksToTest(tests);
+        tests = this._setGlobalHooksToTests(tests);
 
         return tests;
     }

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -515,6 +515,9 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _runBeforeHook (): Promise<boolean> {
+        if (this.test.globalBeforeFn)
+            await this._executeTestFn(TestRunPhase.inTestBeforeHook, this.test.globalBeforeFn);
+
         if (this.test.beforeFn)
             return await this._executeTestFn(TestRunPhase.inTestBeforeHook, this.test.beforeFn);
 
@@ -525,6 +528,9 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _runAfterHook (): Promise<boolean> {
+        if (this.test.globalAfterFn)
+            await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.globalAfterFn);
+
         if (this.test.afterFn)
             return await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.afterFn);
 

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -162,3 +162,29 @@ describe('[API] fixture global before/after hooks', () => {
         return runTests('./testcafe-fixtures/fixture-hooks-global.js', null, { only: 'chrome', hooks });
     });
 });
+
+describe('[API] test global before/after hooks', () => {
+    const hooks = {
+        test: {
+            before: async (t) => {
+                await t
+                    .click('#beforeEach')
+                    .wait(100);
+
+                t.ctx.testBefore = t.ctx.testBefore ? t.ctx.testBefore + 1 : 1;
+                t.ctx.testAfter = t.ctx.testAfter || 0;
+            },
+            after: async (t) => {
+                await t
+                    .click('#afterEach')
+                    .wait(100);
+
+                t.ctx.testAfter++;
+            }
+        }
+    };
+
+    it('Should run hooks for all tests', () => {
+        return runTests('./testcafe-fixtures/test-hooks-global.js', null, { only: 'chrome', hooks });
+    });
+});

--- a/test/functional/fixtures/api/es-next/hooks/testcafe-fixtures/test-hooks-global.js
+++ b/test/functional/fixtures/api/es-next/hooks/testcafe-fixtures/test-hooks-global.js
@@ -1,0 +1,39 @@
+fixture`Fixture 1`
+    .page`http://localhost:3000/fixtures/api/es-next/hooks/pages/index.html`;
+
+test('Test1', async t => {
+    await t
+        .click('#test')
+        .expect(t.ctx.testBefore).eql(1)
+        .expect(t.ctx.testAfter).eql(0);
+});
+
+test
+    .before((t) => {
+        t.ctx.testBefore = t.ctx.testBefore ? t.ctx.testBefore + 1 : 1;
+    })
+    ('Test2', async t => {
+        await t
+            .click('#test')
+            .expect(t.ctx.testBefore).eql(2)
+            .expect(t.ctx.testAfter).eql(0);
+    })
+    .after(async (t) => {
+        t.ctx.testAfter++;
+    });
+
+fixture`Fixture2`
+    .page`http://localhost:3000/fixtures/api/es-next/hooks/pages/index.html`
+    .beforeEach(async (t) => {
+        t.ctx.testBefore = t.ctx.testBefore ? t.ctx.testBefore + 1 : 1;
+    })
+    .afterEach(async (t) => {
+        t.ctx.testAfter++;
+    });
+
+test('Test3', async t => {
+    await t
+        .click('#test')
+        .expect(t.ctx.testBefore).eql(2)
+        .expect(t.ctx.testAfter).eql(0);
+});


### PR DESCRIPTION
[closes DevExpress/testcafe#745]

## Purpose
Realize the possibility to assign global before/after for runTest/fixture/test to perform any actions in the appropriate conditions.

## Approach
1. Add the tests for feature
2. Add the property 'hooks' processing
3. Add execution before/after fixture hooks

## References
https://github.com/DevExpress/testcafe/issues/745

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
